### PR TITLE
feat: add team management module

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -2,12 +2,14 @@ import { Routes } from '@angular/router';
 import { AuthComponent } from './auth/auth.component';
 import { DashboardComponent } from './dashboard/dashboard.component';
 import { KanbanBoardComponent } from './kanban-board/kanban-board.component';
+import { TeamManagementComponent } from './team-management/team-management.component';
 import { AuthGuard } from './guards/auth.guard';
 
 export const routes: Routes = [
   { path: 'login', component: AuthComponent },
   { path: 'dashboard', component: DashboardComponent, canActivate: [AuthGuard] },
   { path: 'boards', component: KanbanBoardComponent, canActivate: [AuthGuard] },
+  { path: 'team', component: TeamManagementComponent, canActivate: [AuthGuard] },
   { path: '', pathMatch: 'full', redirectTo: 'dashboard' },
   { path: '**', redirectTo: 'dashboard' }
 ];

--- a/src/app/dashboard/quick-links/quick-links.component.html
+++ b/src/app/dashboard/quick-links/quick-links.component.html
@@ -5,7 +5,7 @@
       <mat-icon>view_kanban</mat-icon>
       Tablero Kanban
     </button>
-    <button mat-stroked-button (click)="placeholder()">
+    <button mat-stroked-button routerLink="/team">
       <mat-icon>group</mat-icon>
       Gestión de Equipo
     </button>

--- a/src/app/services/team.service.ts
+++ b/src/app/services/team.service.ts
@@ -1,0 +1,73 @@
+import { Injectable } from '@angular/core';
+import { User } from '../models/user';
+
+const TEAM_KEY = 'team';
+
+@Injectable({ providedIn: 'root' })
+export class TeamService {
+  private members: User[] = [];
+
+  constructor() {
+    const data = localStorage.getItem(TEAM_KEY);
+    if (data) {
+      this.members = JSON.parse(data);
+    } else {
+      this.members = [
+        {
+          id: 1,
+          name: 'Katherine',
+          email: 'katherine@example.com',
+          password: '123',
+          initials: 'K',
+          role: 'admin'
+        },
+        {
+          id: 2,
+          name: 'Juan',
+          email: 'juan@example.com',
+          password: '123',
+          initials: 'J',
+          role: 'admin'
+        }
+      ];
+      this.save();
+    }
+  }
+
+  private save() {
+    localStorage.setItem(TEAM_KEY, JSON.stringify(this.members));
+  }
+
+  list(): User[] {
+    return [...this.members];
+  }
+
+  create(member: User) {
+    member.id = Math.max(0, ...this.members.map(m => m.id)) + 1;
+    member.initials = this.getInitials(member.name);
+    this.members.push(member);
+    this.save();
+  }
+
+  update(member: User) {
+    const index = this.members.findIndex(m => m.id === member.id);
+    if (index > -1) {
+      member.initials = this.getInitials(member.name);
+      this.members[index] = member;
+      this.save();
+    }
+  }
+
+  remove(id: number) {
+    this.members = this.members.filter(m => m.id !== id);
+    this.save();
+  }
+
+  private getInitials(name: string) {
+    return name
+      .split(' ')
+      .map(n => n[0])
+      .join('')
+      .toUpperCase();
+  }
+}

--- a/src/app/team-management/team-form.component.css
+++ b/src/app/team-management/team-form.component.css
@@ -1,0 +1,3 @@
+.full-width {
+  width: 100%;
+}

--- a/src/app/team-management/team-form.component.html
+++ b/src/app/team-management/team-form.component.html
@@ -1,0 +1,28 @@
+<h2 mat-dialog-title>{{ member.id ? 'Editar Miembro' : 'Nuevo Miembro' }}</h2>
+<div mat-dialog-content>
+  <form>
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Nombre</mat-label>
+      <input matInput [(ngModel)]="member.name" name="name">
+    </mat-form-field>
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Email</mat-label>
+      <input matInput [(ngModel)]="member.email" name="email">
+    </mat-form-field>
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Rol</mat-label>
+      <mat-select [(ngModel)]="member.role" name="role">
+        <mat-option value="admin">Admin</mat-option>
+        <mat-option value="user">Usuario</mat-option>
+      </mat-select>
+    </mat-form-field>
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Contraseña</mat-label>
+      <input matInput type="password" [(ngModel)]="member.password" name="password">
+    </mat-form-field>
+  </form>
+</div>
+<div mat-dialog-actions align="end">
+  <button mat-button (click)="cancel()">Cancelar</button>
+  <button mat-raised-button color="primary" (click)="save()">Guardar</button>
+</div>

--- a/src/app/team-management/team-form.component.ts
+++ b/src/app/team-management/team-form.component.ts
@@ -1,0 +1,43 @@
+import { Component, Inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { MatDialogModule, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { User } from '../models/user';
+
+@Component({
+  selector: 'app-team-form',
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    MatDialogModule,
+    MatButtonModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSelectModule
+  ],
+  templateUrl: './team-form.component.html',
+  styleUrl: './team-form.component.css'
+})
+export class TeamFormComponent {
+  member: User;
+
+  constructor(
+    private dialogRef: MatDialogRef<TeamFormComponent>,
+    @Inject(MAT_DIALOG_DATA) data: { member: User }
+  ) {
+    this.member = { ...data.member };
+  }
+
+  save() {
+    this.dialogRef.close(this.member);
+  }
+
+  cancel() {
+    this.dialogRef.close();
+  }
+}

--- a/src/app/team-management/team-management.component.css
+++ b/src/app/team-management/team-management.component.css
@@ -1,0 +1,15 @@
+.team-management {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.full-width {
+  width: 100%;
+}

--- a/src/app/team-management/team-management.component.html
+++ b/src/app/team-management/team-management.component.html
@@ -1,0 +1,41 @@
+<div class="team-management card">
+  <div class="header">
+    <h2>Equipo</h2>
+    <button mat-raised-button color="primary" (click)="add()">
+      <mat-icon>person_add</mat-icon>
+      Agregar
+    </button>
+  </div>
+
+  <table mat-table [dataSource]="members" class="full-width">
+    <ng-container matColumnDef="name">
+      <th mat-header-cell *matHeaderCellDef>Nombre</th>
+      <td mat-cell *matCellDef="let m">{{ m.name }}</td>
+    </ng-container>
+
+    <ng-container matColumnDef="email">
+      <th mat-header-cell *matHeaderCellDef>Email</th>
+      <td mat-cell *matCellDef="let m">{{ m.email }}</td>
+    </ng-container>
+
+    <ng-container matColumnDef="role">
+      <th mat-header-cell *matHeaderCellDef>Rol</th>
+      <td mat-cell *matCellDef="let m">{{ m.role }}</td>
+    </ng-container>
+
+    <ng-container matColumnDef="actions">
+      <th mat-header-cell *matHeaderCellDef>Acciones</th>
+      <td mat-cell *matCellDef="let m">
+        <button mat-icon-button color="primary" (click)="edit(m)">
+          <mat-icon>edit</mat-icon>
+        </button>
+        <button mat-icon-button color="warn" (click)="delete(m)">
+          <mat-icon>delete</mat-icon>
+        </button>
+      </td>
+    </ng-container>
+
+    <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+    <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+  </table>
+</div>

--- a/src/app/team-management/team-management.component.ts
+++ b/src/app/team-management/team-management.component.ts
@@ -1,0 +1,70 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatTableModule } from '@angular/material/table';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import { TeamService } from '../services/team.service';
+import { User } from '../models/user';
+import { TeamFormComponent } from './team-form.component';
+
+@Component({
+  selector: 'app-team-management',
+  standalone: true,
+  imports: [
+    CommonModule,
+    MatTableModule,
+    MatButtonModule,
+    MatIconModule,
+    MatDialogModule
+  ],
+  templateUrl: './team-management.component.html',
+  styleUrl: './team-management.component.css'
+})
+export class TeamManagementComponent implements OnInit {
+  members: User[] = [];
+  displayedColumns = ['name', 'email', 'role', 'actions'];
+
+  constructor(private team: TeamService, private dialog: MatDialog) {}
+
+  ngOnInit() {
+    this.load();
+  }
+
+  load() {
+    this.members = this.team.list();
+  }
+
+  add() {
+    const dialogRef = this.dialog.open(TeamFormComponent, {
+      data: { member: { id: 0, name: '', email: '', role: 'user', password: '', initials: '' } }
+    });
+
+    dialogRef.afterClosed().subscribe((result: User | undefined) => {
+      if (result) {
+        this.team.create(result);
+        this.load();
+      }
+    });
+  }
+
+  edit(member: User) {
+    const dialogRef = this.dialog.open(TeamFormComponent, {
+      data: { member: { ...member } }
+    });
+
+    dialogRef.afterClosed().subscribe((result: User | undefined) => {
+      if (result) {
+        this.team.update(result);
+        this.load();
+      }
+    });
+  }
+
+  delete(member: User) {
+    if (confirm('¿Eliminar miembro?')) {
+      this.team.remove(member.id);
+      this.load();
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add TeamService for storing team members
- create team management component with add/edit/delete dialogs
- wire dashboard quick link and routing to new module

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_68a11861b3b083239c6a09a826b3fa51